### PR TITLE
fix: Update README example for v2.0.0+ of mime

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ gulp.task('default', function () {
 				},
 				parser: function (base, filename, encoding, minify) {
 					var content = fs.readFileSync(filename).toString('base64');
-					var contentType = mime.lookup(filename);
+					var contentType = mime.getType(filename);
 					return 'data:' + contentType + ';base64,' + content;
 				}
 			}


### PR DESCRIPTION
Change: https://www.npmjs.com/package/mime/v/2.0.0
* lookup() renamed to getType()